### PR TITLE
Added volume manipulation filter in order to make volume adjustments

### DIFF
--- a/ames.sh
+++ b/ames.sh
@@ -21,6 +21,7 @@ SCREENSHOT_FIELD="image"
 OUTPUT_MONITOR=""
 AUDIO_BITRATE="64k"
 AUDIO_FORMAT="opus"
+AUDIO_VOLUME="1"
 IMAGE_FORMAT="webp"
 # -2 to calculate dimension while preserving aspect ratio.
 IMAGE_WIDTH="-2"
@@ -241,7 +242,7 @@ record() {
             -f pulse \
             -i "$output" \
             -ac 2 \
-            -af 'silenceremove=1:0:-50dB' \
+            -af "volume=${AUDIO_VOLUME},silenceremove=1:0:-50dB" \
             -ab $AUDIO_BITRATE \
             "$audioFile" 1>/dev/null &
 	echo "$!" >> "$recordingToggle"

--- a/config
+++ b/config
@@ -4,6 +4,7 @@ SCREENSHOT_FIELD="image"
 OUTPUT_MONITOR=""
 AUDIO_BITRATE="64k"
 AUDIO_FORMAT="opus"
+AUDIO_VOLUME="1"
 IMAGE_FORMAT="webp"
 # -2 to calculate dimension while preserving aspect ratio.
 IMAGE_WIDTH="-2"


### PR DESCRIPTION
When using the script for the first time I noticed that the volume of my recordings in my Anki cards is quite low, first I thought it was because my VN audio settings were low, but after experimenting with the VNs audio settings the audio in the cards remained low.

then I realized it might be because of my headphones' audio levels which are always < 50%, and when bumping them to 100% the volume in the Anki card was also increased.

so instead of making myself deaf, I added another filter to the FFmpeg which does volume manipulation. The volume increase or decrease is controlled by the new ``AUDIO_VOLUME`` bash variable which is set to 1 as a default, I myself found that for my setup setting it to 10 (10x volume increase) made it a bit louder than hearing the same line on the VN with my headphones set to the usual 50% volume. I guess people will have to experiment with what increase (or decrease) works for them best, but I think it's a good addition to the script overall.

more information on the volume manipulation filter can be found here:
https://trac.ffmpeg.org/wiki/AudioVolume

