### PR TITLE
replace X11 support with Sway support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,34 @@
-# ames
-anki media extractor script(ames): Update anki cards with desktop audio, screenshots, and clipboard sentences on GNU/linux
+# awes
+anki wlroots extractor script(awes): Update anki cards with desktop audio, screenshots, and clipboard sentences on GNU/linux. This script is a rewrite of [ames](https://github.com/eshrh/ames) for wlroots compositors, specifically Sway. The only option that may not work on other wlroots compositors is `-w`, which relies on `swaymsg` to selecting the active window.
 
-Ames automates the process of adding information and media to your latest added Anki card; making immersion mining smoother and more efficient.
+Awes automates the process of adding information and media to your latest added Anki card; making immersion mining smoother and more efficient.
 
 ## Requirements
 + A bash interpreter
 + Anki and [AnkiConnect](https://ankiweb.net/shared/info/2055492159). *Note that Anki must be running*.
-+ X: Wayland version coming soon (?)
-+ `pulseaudio` and `pactl`: detecting and recording from audio monitors
++ A wlroots compositor, specifically `sway` (GNOME doesn't support the screenshot protocol grim/slurp uses)
++ `pulseaudio` and `pactl`: detecting and recording from audio monitors. `pipewire-pulse` is also supported.
 + `ffmpeg`: encoding desktop audio
-+ `maim`: screenshots
-+ `xdotool`: detecting active windows
++ `grim`: screenshots
++ `slurp`: select a region
++ `jq`: processing JSON data for active window selection
 + `libnotify`: sending notifications
-+ `xsel`: pasting clipboard content
-
++ `wl-clipboard`: pasting clipboard content
 
 ## Installation
 ### General
-1. Download the ames.sh script somewhere safe
+1. Download the awes.sh script somewhere safe
 2. Edit the script and change the first two lines to match the names of your Anki model image and audio fields.
 3. Bind the following commands to any key in your DE, WM, sxhkd, xbindkeysrc, etc.
-    * `sh ~/path/to/ames.sh -r`: press once to start recording, and again to stop and export the audio clip to your latest-created Anki card.
-    * `sh ~/path/to/ames.sh -s`: prompt for an interactive screenshot selection
-    * `sh ~/path/to/ames.sh -a`: repeat the previous screenshot selection. If there is no previous selection, default to -s.
-    * `sh ~/path/to/ames.sh -w`: screenshot the currently active window (requires xdotool)
-    * `sh ~/path/to/ames.sh -c`: pastes the currently copied sentence in the clipboard (requires xsel)
+    * `sh ~/path/to/awes.sh -r`: press once to start recording, and again to stop and export the audio clip to your latest-created Anki card.
+    * `sh ~/path/to/awes.sh -s`: prompt for an interactive screenshot selection
+    * `sh ~/path/to/awes.sh -a`: repeat the previous screenshot selection. If there is no previous selection, default to -s.
+    * `sh ~/path/to/awes.sh -w`: screenshot the currently active window (requires xdotool)
+    * `sh ~/path/to/awes.sh -c`: pastes the currently copied sentence in the clipboard (requires xsel)
 
-### Arch users
-1. Install the `ames` package from the AUR
-2. Copy the default config: `mkdir -p ~/.config/ames/ && cp /usr/share/ames/config ~/.config/ames/config`
-3. Edit the config file however you like, but make sure your Anki image and audio fields are correct.
-4. Bind the same commands however you want, but now the `ames` command should be in your PATH; so you can bind, for example, `ames -s` instead of `sh ~/path/to/ames.sh -s`
-    
 ## Notes
-+ You may also define config options in `~/.config/ames/config`. These must be bash variable declarations, with no spaces like in the script.
-+ ames tries to pick the right output monitor automatically. If this doesn't work for you, you can first list monitor sinks with `pactl list | grep -A2 '^Source #'` and then redefine the `OUTPUT_MONITOR` variable in the script or a config file with the name of the correct sink.
++ You may also define config options in `~/.config/awes/config`. These must be bash variable declarations, with no spaces like in the script.
++ awes tries to pick the right output monitor automatically. If this doesn't work for you, you can first list monitor sinks with `pactl list | grep -A2 '^Source #'` and then redefine the `OUTPUT_MONITOR` variable in the script or a config file with the name of the correct sink.
 + By default, images are scaled to a height of 300px
-+ Prefix your ames command with `LANG=ja` for japanese notifications to achieve *maximum immersion*
-  
++ Prefix your awes command with `LANG=ja` for japanese notifications to achieve *maximum immersion*
++ The most common issue is not matching up the names of your Anki model's image, audio, and sentence fields with the ones configured in awes, so if your card isn't being updated, check that these field names are set correctly in `~/.config/awes/config` or directly in the script's variables..

--- a/awes.sh
+++ b/awes.sh
@@ -28,7 +28,7 @@ IMAGE_FORMAT="webp"
 IMAGE_WIDTH="-2"
 IMAGE_HEIGHT="300"
 
-CONFIG_FILE_PATH="$HOME/.config/ames/config"
+CONFIG_FILE_PATH="$HOME/.config/awes/config"
 
 if [[ -f "$CONFIG_FILE_PATH" ]]; then
     # shellcheck disable=SC1090
@@ -182,11 +182,11 @@ update_sound() {
 }
 
 screenshot() {
-    local -r geom=$(slop)
-    local -r path=$(mktemp /tmp/maim-screenshot.XXXXXX.png)
+    local -r geom=$(slurp)
+    local -r path=$(mktemp /tmp/grim-screenshot.XXXXXX.png)
     local -r converted_path="/tmp/$(basename -- "$path" | cut -d "." -f-2).$IMAGE_FORMAT"
 
-    maim --hidecursor "$path" -g "$geom"
+    grim -g "$geom" "$path"
     ffmpeg -nostdin \
         -hide_banner \
         -loglevel error \
@@ -195,18 +195,18 @@ screenshot() {
         "$converted_path"
 
     rm "$path"
-    echo "$geom" >/tmp/previous-maim-screenshot
+    echo "$geom" >/tmp/previous-grim-screenshot
     store_file "$converted_path"
     update_img "$(basename -- "$converted_path")"
     notify_screenshot_add
 }
 
 again() {
-    local -r path=$(mktemp /tmp/maim-screenshot.XXXXXX.png)
+    local -r path=$(mktemp /tmp/grim-screenshot.XXXXXX.png)
     local -r converted_path="/tmp/$(basename -- "$path" | cut -d "." -f-2).$IMAGE_FORMAT"
 
-    if [[ -f /tmp/previous-maim-screenshot ]]; then
-        maim --hidecursor "$path" -g "$(cat /tmp/previous-maim-screenshot)"
+    if [[ -f /tmp/previous-grim-screenshot ]]; then
+        grim -g "$(cat /tmp/previous-grim-screenshot)" "$path"
         ffmpeg -nostdin \
             -hide_banner \
             -loglevel error \
@@ -225,10 +225,10 @@ again() {
 }
 
 screenshot_window() {
-    local -r path=$(mktemp /tmp/maim-screenshot.XXXXXX.png)
+    local -r path=$(mktemp /tmp/grim-screenshot.XXXXXX.png)
     local -r converted_path="/tmp/$(basename -- "$path" | cut -d "." -f-2).$IMAGE_FORMAT"
 
-    maim --hidecursor "$path" -i "$(xdotool getactivewindow)"
+    swaymsg -t get_tree | jq -r '.. | select(.pid? and .visible?) | .rect | "\(.x),\(.y) \(.width)x\(.height)"' | slurp -o | grim -g - "$path"
     ffmpeg -nostdin \
         -hide_banner \
         -loglevel error \
@@ -297,7 +297,7 @@ record() {
 }
 
 clipboard(){
-    local -r sentence=$(xsel -b)
+    local -r sentence=$(wl-paste)
 
     update_sentence "${sentence}"
 }


### PR DESCRIPTION
This branch implements support for wlroots compositors in ames. The `-w` option is dependent on `swaymsg`, so I am unsure if all wlroots compositors will be able to select the active window using this option.

It simultaneously deprecates Xorg support. I've renamed `ames` to `awes` across the repository to make it possible to have both scripts/config files installed at the same time (for example, if a user regularly switches between X and Wayland sessions).

This issue partially addresses #2, at least for wlroots compositors. This script is incompatible with other Wayland compositors, including kwin and Mutter, as `grim` and `slurp` rely on the `wlr-screencopy` Wayland protocol which these compositors have not implemented support for.

This is my first pull request, so I'm not sure, but I believe that a contributor needs to create a branch in this repository in order to merge these changes. I've created this PR against `master` for now, with the expectation that a contributor will change the target branch to another, more suitable one.