### PR TITLE
Escape clipboard text and add notifications for -c

### DIFF
--- a/ames.sh
+++ b/ames.sh
@@ -298,10 +298,17 @@ record() {
     fi
 }
 
-clipboard(){
+clipboard() {
     local -r sentence=$(xsel -b)
 
     update_sentence "${sentence}"
+
+    if [[ "$LANG" == en* ]]; then
+        notify-send --hint=int:transient:1 -t 500 -u normal "Sentence added"
+    fi
+    if [[ "$LANG" == ja* ]]; then
+        notify-send --hint=int:transient:1 -t 500 -u normal "例文付けました"
+    fi
 }
 
 if [[ -z ${1-} ]]; then

--- a/ames.sh
+++ b/ames.sh
@@ -137,7 +137,9 @@ update_sentence() {
 
     update_request=${update_request/<id>/$newest_card_id}
     update_request=${update_request/<SENTENCE_FIELD>/$SENTENCE_FIELD}
-    update_request=${update_request/<sentence>/$1}
+    sentence_esc=${1//\\/\\\\}
+    sentence_esc=${sentence_esc//\"/\\\"}
+    update_request=${update_request/<sentence>/$sentence_esc}
     safe_request "$update_request"
 }
 


### PR DESCRIPTION
Running `ames.sh -c` copies the current text in the clipboard into
the sentence field in Anki. However, the current text is directly
substituted unescaped into the JSON request to AnkiConnect. If the
current text contains the `"` (double quote) or `\` (backslash)
characters, this can cause the JSON string itself to end early.

These changes fix this issue by first escaping the
text by substituting `\ -> \\` and then `" -> \"`.

In addition, notifications are provided for `ames.sh -c` in both English
and Japanese locales in the same style as the other notifications.
