### PR TITLE
Fixing the case where XDG_CONFIG_HOME variable is not set

### DIFF
--- a/ames.sh
+++ b/ames.sh
@@ -32,7 +32,7 @@ IMAGE_HEIGHT="300"
 get_config_dir() {
     # get the configuration directory
     # adapted from https://xdgbasedirectoryspecification.com/
-    local config_dir="$XDG_CONFIG_HOME"
+    local config_dir="${XDG_CONFIG_HOME-}"
     if [ -z "$config_dir" ] || [ "${config_dir::1}" != '/' ]; then
         echo -n "$HOME/.config/ames"
     else


### PR DESCRIPTION
Because `set -u` is used at the top of the script, an error is thrown if $XDG_CONFIG_HOME is not set. This pull request adjusts the request for the $XDG_CONFIG_HOME, so that it returns an empty string if the variable is not set, without throwing an error.