### PR TITLE
Run pactl info with LC_ALL=C to get consistent output

### DIFF
--- a/ames.sh
+++ b/ames.sh
@@ -395,7 +395,7 @@ record_start() {
     echo "$audio_file" >"$recording_toggle"
 
     if [ "$OUTPUT_MONITOR" == "" ]; then
-        local -r output="$(pactl info \
+        local -r output="$(LC_ALL=C pactl info \
                                | grep 'Default Sink' \
                                | awk '{print $NF ".monitor"}')"
     else


### PR DESCRIPTION
The output of pactl info is translated according to the user's LANG or LC_CTYPE environment variable so the `grep 'Default Sink'` that follow `pactl info` will fail to find the relevant line if "Default Sink" has been translated into another language.


```sh
~/Documents/Japanese/ames-anki_media_extractor_script on locale_insensitive_pactl !1                   
❯ LANG=ja_JP.UTF-8 pactl info | tail -n 3
デフォルトシンク: alsa_output.pci-0000_00_1b.0.analog-stereo
デフォルトソース: alsa_input.pci-0000_00_1b.0.analog-stereo
クッキー: 682e:f43d

~/Documents/Japanese/ames-anki_media_extractor_script on locale_insensitive_pactl !1                   
❯ LANG=en_US.UTF-8 pactl info | tail -n 3 # not sure why that is
デフォルトシンク: alsa_output.pci-0000_00_1b.0.analog-stereo
デフォルトソース: alsa_input.pci-0000_00_1b.0.analog-stereo
クッキー: 682e:f43d

~/Documents/Japanese/ames-anki_media_extractor_script on locale_insensitive_pactl !1                   
❯ LC_ALL=C pactl info | tail -n 3
Default Sink: alsa_output.pci-0000_00_1b.0.analog-stereo
Default Source: alsa_input.pci-0000_00_1b.0.analog-stereo
Cookie: 682e:f43d
```

This pull request fixes the audio recording for users on a Japanese locale.